### PR TITLE
Fix Draco/gltfpack interaction to prevent hangs

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI module."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -83,75 +84,95 @@ class TestCLIOptions:
 class TestDracoGltfpackInteraction:
     """Tests for Draco/gltfpack interaction to prevent hangs."""
 
+    @staticmethod
+    def _make_glb(tmp_path: Path) -> Path:
+        """Create a minimal GLB file for testing."""
+        path = tmp_path / "input.glb"
+        path.write_bytes(b"\x00" * 20)
+        return path
+
+    @patch("notso_glb.wasm.is_available", return_value=True)
     @patch("notso_glb.exporters.optimize_and_export")
-    def test_draco_disabled_when_gltfpack_enabled(
-        self, mock_export: MagicMock, tmp_path: object
+    def test_draco_disabled_when_gltfpack_available(
+        self, mock_export: MagicMock, mock_wasm: MagicMock, tmp_path: Path
     ) -> None:
-        """Draco should be disabled at export when gltfpack is enabled."""
-        import tempfile
+        """Draco should be disabled at export when gltfpack is available."""
+        glb = self._make_glb(tmp_path)
+        mock_export.return_value = None  # simulate export failure to skip gltfpack
 
-        with tempfile.NamedTemporaryFile(suffix=".glb", delete=False) as f:
-            # Write minimal GLB header so the file exists
-            f.write(b"\x00" * 20)
-            f.flush()
+        runner.invoke(app, [str(glb), "--draco", "--gltfpack"])
 
-            mock_export.return_value = None  # simulate export failure to skip gltfpack
-
-            runner.invoke(app, [f.name, "--draco", "--gltfpack"])
-
-        # The export should have been called with use_draco=False
         mock_export.assert_called_once()
         assert mock_export.call_args.kwargs["use_draco"] is False
 
     @patch("notso_glb.exporters.optimize_and_export")
     def test_draco_kept_when_gltfpack_disabled(
-        self, mock_export: MagicMock, tmp_path: object
+        self, mock_export: MagicMock, tmp_path: Path
     ) -> None:
         """Draco should remain enabled when gltfpack is disabled."""
-        import tempfile
+        glb = self._make_glb(tmp_path)
+        mock_export.return_value = None
 
-        with tempfile.NamedTemporaryFile(suffix=".glb", delete=False) as f:
-            f.write(b"\x00" * 20)
-            f.flush()
-
-            mock_export.return_value = None
-
-            runner.invoke(app, [f.name, "--draco", "--no-gltfpack"])
+        runner.invoke(app, [str(glb), "--draco", "--no-gltfpack"])
 
         mock_export.assert_called_once()
         assert mock_export.call_args.kwargs["use_draco"] is True
 
+    @patch("notso_glb.wasm.is_available", return_value=True)
     @patch("notso_glb.exporters.optimize_and_export")
     def test_draco_disabled_message_shown(
-        self, mock_export: MagicMock, tmp_path: object
+        self, mock_export: MagicMock, mock_wasm: MagicMock, tmp_path: Path
     ) -> None:
         """User should be informed when Draco is auto-disabled for gltfpack."""
-        import tempfile
+        glb = self._make_glb(tmp_path)
+        mock_export.return_value = None
 
-        with tempfile.NamedTemporaryFile(suffix=".glb", delete=False) as f:
-            f.write(b"\x00" * 20)
-            f.flush()
-
-            mock_export.return_value = None
-
-            result = runner.invoke(app, [f.name, "--draco", "--gltfpack"])
+        result = runner.invoke(app, [str(glb), "--draco", "--gltfpack"])
 
         assert "draco disabled" in result.output.lower()
 
+    @patch("notso_glb.wasm.is_available", return_value=True)
+    @patch("notso_glb.exporters.optimize_and_export")
+    def test_draco_disabled_message_has_warn_prefix(
+        self, mock_export: MagicMock, mock_wasm: MagicMock, tmp_path: Path
+    ) -> None:
+        """Draco-disabled message should follow [WARN] convention."""
+        glb = self._make_glb(tmp_path)
+        mock_export.return_value = None
+
+        result = runner.invoke(app, [str(glb), "--draco", "--gltfpack"])
+
+        assert "[warn]" in result.output.lower()
+
+    @patch("notso_glb.wasm.is_available", return_value=True)
     @patch("notso_glb.exporters.optimize_and_export")
     def test_no_draco_message_when_draco_already_off(
-        self, mock_export: MagicMock, tmp_path: object
+        self, mock_export: MagicMock, mock_wasm: MagicMock, tmp_path: Path
     ) -> None:
         """No Draco-disabled message when user already passed --no-draco."""
-        import tempfile
+        glb = self._make_glb(tmp_path)
+        mock_export.return_value = None
 
-        with tempfile.NamedTemporaryFile(suffix=".glb", delete=False) as f:
-            f.write(b"\x00" * 20)
-            f.flush()
-
-            mock_export.return_value = None
-
-            result = runner.invoke(app, [f.name, "--no-draco", "--gltfpack"])
+        result = runner.invoke(app, [str(glb), "--no-draco", "--gltfpack"])
 
         # Should NOT show the "Draco disabled" message since user already disabled it
         assert "draco disabled" not in result.output.lower()
+
+    @patch("notso_glb.wasm.is_available", return_value=False)
+    @patch("notso_glb.cli.find_gltfpack", return_value=None)
+    @patch("notso_glb.exporters.optimize_and_export")
+    def test_draco_kept_when_gltfpack_unavailable(
+        self,
+        mock_export: MagicMock,
+        mock_find: MagicMock,
+        mock_wasm: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Draco should remain enabled when --gltfpack is set but no backend is available."""
+        glb = self._make_glb(tmp_path)
+        mock_export.return_value = None
+
+        runner.invoke(app, [str(glb), "--draco", "--gltfpack"])
+
+        mock_export.assert_called_once()
+        assert mock_export.call_args.kwargs["use_draco"] is True


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where using both `--draco` and `--gltfpack` flags together would cause the tool to hang. The root cause is that gltfpack cannot parse Draco-compressed files, leading to a deadlock when it attempts to process the output.

## Key Changes
- **Disable Draco at export time when gltfpack is enabled**: Instead of detecting Draco compression after export and conditionally disabling gltfpack's mesh compression, we now proactively disable Draco during the export stage when gltfpack post-processing is requested. This prevents gltfpack from receiving Draco-compressed input.
- **Simplify gltfpack mesh compression logic**: Removed the runtime detection of Draco compression in the exported file and the conditional `mesh_compress` flag. Since Draco is now disabled at export time, `mesh_compress=True` is always safe.
- **Add user feedback**: Display a warning message when Draco is automatically disabled due to gltfpack being enabled, so users understand why their `--draco` flag is being overridden.
- **Add comprehensive test coverage**: Added tests to verify:
  - Draco is disabled when both flags are used
  - Draco remains enabled when only `--draco` is used
  - User receives appropriate feedback messages
  - No spurious messages when user already disabled Draco

## Implementation Details
- The fix is applied early in the `optimize()` function, before calling `optimize_and_export()`, ensuring gltfpack never receives Draco-compressed input
- The solution is backward compatible and doesn't affect existing workflows
- Removed the now-unnecessary `has_draco_compression()` import from the gltfpack post-processing section

https://claude.ai/code/session_01HnJcEHhdhsbtQjg9aWdzkj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically disables Draco compression when gltfpack post-processing is available and notifies users with a warning.
  * Preserves Draco when gltfpack is unavailable; gltfpack post-processing is skipped if not present.

* **Tests**
  * Added tests covering Draco/gltfpack interactions and the expected user-facing warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->